### PR TITLE
AnswerCardsResponse does not return user state

### DIFF
--- a/api/basic_flow_test.py
+++ b/api/basic_flow_test.py
@@ -373,6 +373,9 @@ def answer_deck(base_url: str, token: str, course_id: str, lesson_id: str, deck:
         headers=auth_headers(token),
         timeout=TIMEOUT,
     )
+
+    assert response.json().get("success") is True
+
     log_response(
         "POST /courses/{courseId}/lessons/{lessonId}/decks/{deckId}/answer", response)
     response.raise_for_status()

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1100,16 +1100,6 @@ components:
         success:
           type: boolean
           description: Whether the operation succeeded
-        deck_completed:
-          type: boolean
-          description: Whether the deck was completed with these answers
-        lesson_completed:
-          type: boolean
-          description: Whether the lesson was completed
-        user_progress:
-          allOf:
-            - $ref: '#/components/schemas/UserCourseProgress'
-          nullable: true
       required:
         - success
 


### PR DESCRIPTION
1. https://github.com/XaviFP/toshokan/blob/master/course/internal/grpc/server.go#L494
2. https://github.com/XaviFP/toshokan/blob/master/gate/internal/gate/courses_handlers.go#L209

Returning `deck_completed` and ` lesson_completed` was just an initial idea/draft but it is not what's happening now.
For the time being, clients are expected to call  `GetLessonState` to fetch this information once a deck round is done. 