### PR TITLE
Keep lesson_decks in sync

### DIFF
--- a/course/cmd/course/main.go
+++ b/course/cmd/course/main.go
@@ -44,7 +44,7 @@ func main() {
 	}
 	defer redisClient.Close()
 
-	pgRepo := course.NewPGRepository(db)
+	pgRepo := course.NewPGRepository(logger.With("component", "pgRepository"), db)
 	redisRepo := course.NewRedisRepository(redisClient, pgRepo)
 
 	// Connect to deck service


### PR DESCRIPTION
- Moving forward it would be wise to use a transaction wrapper to not repeat code 
- I'm generally not a fan of doing things like `ParseDeckReferences` in the repository, even more so when this function has been called already in upper layers. I decided to go with this implementation for now because it was "cleaner" for this PR (easier to review, only changes in the repo). In a follow-up PR it would just be a matter of changing the Interface and accepting the already parsed deck ids as well as the lesson (in the repo). 